### PR TITLE
use CfnParameter instead of CDK context to pass SES verified email pa…

### DIFF
--- a/bedrock-agent-implementation/README.md
+++ b/bedrock-agent-implementation/README.md
@@ -89,15 +89,18 @@ step to activate your virtualenv.
     ```
 7. CDK bootstrap 
    ```
-   cdk bootstrap -c sender=<the email verified in SES> -c recipient=<the email verified in SES> --all
+   cdk bootstrap
    ```
 8. At this point you can now synthesize the CloudFormation template for this code.
     ```
-    cdk synth -c sender=<the email verified in SES> -c recipient=<the email verified in SES> --all
+    cdk synth
     ```
 9. Deploy the application
     ```
-    cdk deploy -c sender=<the email verified in SES> -c recipient=<the email verified in SES> --all --require-approval never
+    cdk deploy --all \
+    --require-approval never \
+    --parameters BedrockAgentImplGenAIStack:sender=<The SES verified sender's email> \
+    --parameters BedrockAgentImplGenAIStack:recipient=<The SES verified recipient's email>
     ```
 Once the CDK deployment has completed, there will be a Streamlit URL printed out alongside with deployment time in CDK Outputs.
 
@@ -106,6 +109,6 @@ Once the CDK deployment has completed, there will be a Streamlit URL printed out
 ### Cleanup
 Run the following commands to destroy all Stacks. 
 ```
-cdk destroy -c sender=<the email verified in SES> -c recipient=<the email verified in SES> --all
+cdk destroy --all
 ```
 Enter `y` upon the prompt to destroy each Stack.

--- a/langchain-multi-route-implementation/README.md
+++ b/langchain-multi-route-implementation/README.md
@@ -107,15 +107,18 @@ step to activate your virtualenv.
     ```
 7. CDK bootstrap 
    ```
-   cdk bootstrap -c sender=<the email verified in SES> -c recipient=<the email verified in SES> --all
+   cdk bootstrap
    ```
 8. At this point you can now synthesize the CloudFormation template for this code.
     ```
-    cdk synth -c sender=<the email verified in SES> -c recipient=<the email verified in SES> --all
+    cdk synth
     ```
 9.  Deploy the application
     ```
-    cdk deploy -c sender=<the email verified in SES> -c recipient=<the email verified in SES> --all --require-approval never
+    cdk deploy --all \
+    --require-approval never \
+    --parameters MultiRouteChainActionLambdaStack:sender=<The SES verified sender's email> \
+    --parameters MultiRouteChainActionLambdaStack:recipient=<The SES verified recipient's email>
     ```
 
 Once the CDK deployment has completed, there will be a Streamlit URL printed out alongside with deployment time in CDK Outputs.
@@ -125,7 +128,7 @@ Once the CDK deployment has completed, there will be a Streamlit URL printed out
 ### Cleanup
 Run the following commands to destroy all Stacks. 
 ```
-cdk destroy -c sender=<the email verified in SES> -c recipient=<the email verified in SES> --all
+cdk destroy --all
 ```
 Enter `y` upon the prompt to destroy each Stack.
 

--- a/langchain-multi-route-implementation/langchain_multi_route_implementation/stacks/action_lambda_stack.py
+++ b/langchain-multi-route-implementation/langchain_multi_route_implementation/stacks/action_lambda_stack.py
@@ -4,6 +4,7 @@ import aws_cdk as cdk
 from constructs import Construct
 from aws_cdk import (
     Stack,
+    CfnParameter,
     aws_iam as iam,
     aws_lambda as _lambda,
 )
@@ -17,8 +18,10 @@ class ActionLambdaStack(Stack):
     def __init__(self, scope: Construct, construct_id: str) -> None:
         super().__init__(scope, construct_id)
 
-        sender = self.node.try_get_context('sender')
-        recipient = self.node.try_get_context('recipient')
+        sender = CfnParameter(self, "sender", type="String",
+                              description="The sender's email for SES email notification")
+        recipient = CfnParameter(self, "recipient", type="String",
+                              description="The recipient's email for SES email notification")
 
         action_lambda = _lambda.Function(
             self, "SESActionLambda",
@@ -27,8 +30,8 @@ class ActionLambdaStack(Stack):
                 'langchain_multi_route_implementation/ses_action_lambda'),
             handler='lambda_function.lambda_handler',
             environment={
-                'SENDER': sender,
-                'RECIPIENT': recipient
+                'SENDER': sender.value_as_string,
+                'RECIPIENT': recipient.value_as_string
             },
         )
 


### PR DESCRIPTION
- Use CfnParameter instead of CDK context to pass SES verified email parameters
- Change deployment guide accordingly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
